### PR TITLE
Make CPUTempMeter compatible with Orange Pi boards

### DIFF
--- a/linux/CPUTempMeter.c
+++ b/linux/CPUTempMeter.c
@@ -42,8 +42,9 @@ static void CPUTempMeter_updateValues(Meter* this, char* buffer, int len) {
    double temperature;
    temperature = strtod(line, NULL);
    free(line);
-
-   temperature /= 1000.0;
+   // some of the systems(e.g Orange Pi) show real temperature in Celcius and therefore we do not need to divide by 1000 
+   if (temperature > 1000.0) temperature /= 1000.0;
+ 
    this->values[0] = temperature;
 
    snprintf(buffer, len, "%d/%d", (int)this->values[0], (int)this->total);


### PR DESCRIPTION
Hi there, I wanted to use this fork of htop but found out CPU temperature doesn't work for Orange Pi boards, all other features seem to be Ok, if you'd like to have full compatibility with OPi you can pull this change.
The solution isn't really clean, but i guess it's good enough if it has to work just with RPi

čau!